### PR TITLE
Gpxjs extensions parsing

### DIFF
--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -250,13 +250,16 @@ export const parseGPXWithCustomParser = (
 				for (const extension of Array.from(
 					extensionsElement.childNodes
 				)) {
+					// Skip non-element nodes
+					if (extension.nodeType !== 1) continue
+
 					const name = extension.nodeName
 
 					// Parse the extension data with support for the browser or an xml parser
 					extensions[name] = parseFloat(
 						(extension as Element).innerHTML != undefined
 							? (extension as Element).innerHTML
-							: (extension as Element).childNodes[0]
+							: (extension as Element)
 									.textContent ?? ""
 					)
 				}

--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -259,7 +259,7 @@ export const parseGPXWithCustomParser = (
 					extensions[name] = parseFloat(
 						(extension as Element).innerHTML != undefined
 							? (extension as Element).innerHTML
-							: (extension as Element)
+							: (extension as Element).childNodes[0]
 									.textContent ?? ""
 					)
 				}


### PR DESCRIPTION
Encountered this issue while trying to parse a GPX with extensions. 

The array from extensionsElement.childNodes will include not only element nodes, which were resulting in an error when trying to get the textContent out of them.