### PR TITLE
Add Biome for linting and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
               with:
                   node-version: "24.x"
             - run: npm ci
+            - run: npx biome check .
             - run: npx playwright install --with-deps chromium
             - run: npm run build
             - run: npx vitest run

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,42 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+	"vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+	"files": { "includes": ["**", "!!**/dist"] },
+	"formatter": {
+		"enabled": true,
+		"formatWithErrors": false,
+		"indentStyle": "tab",
+		"indentWidth": 4,
+		"lineEnding": "lf",
+		"lineWidth": 80,
+		"attributePosition": "auto",
+		"bracketSameLine": false,
+		"bracketSpacing": true,
+		"expand": "auto",
+		"useEditorconfig": true
+	},
+	"linter": { "enabled": true, "rules": { "preset": "recommended" } },
+	"javascript": {
+		"formatter": {
+			"jsxQuoteStyle": "double",
+			"quoteProperties": "asNeeded",
+			"trailingCommas": "es5",
+			"semicolons": "asNeeded",
+			"arrowParentheses": "always",
+			"bracketSameLine": false,
+			"quoteStyle": "single",
+			"attributePosition": "auto",
+			"bracketSpacing": true
+		}
+	},
+	"html": {
+		"formatter": {
+			"indentScriptAndStyle": false,
+			"selfCloseVoidElements": "always"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": { "source": { "organizeImports": "on" } }
+	}
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,10 +1,10 @@
-export { ParsedGPX } from "./parsed_gpx"
-export { parseGPX, parseGPXWithCustomParser } from "./parse"
-export { stringifyGPX } from "./stringify"
 export {
-	calculateDuration,
 	calculateDistance,
+	calculateDuration,
 	calculateElevation,
 	calculateSlopes,
-} from "./math_helpers"
-export * from "./types"
+} from './math_helpers'
+export { parseGPX, parseGPXWithCustomParser } from './parse'
+export { ParsedGPX } from './parsed_gpx'
+export { stringifyGPX } from './stringify'
+export * from './types'

--- a/lib/math_helpers.ts
+++ b/lib/math_helpers.ts
@@ -1,6 +1,5 @@
-import { Point, Distance, Elevation, Duration, Options } from "./types"
-
-import { DEFAULT_OPTIONS } from "./options"
+import { DEFAULT_OPTIONS } from './options'
+import type { Distance, Duration, Elevation, Options, Point } from './types'
 
 export type MathHelperFunction = (points: Point[], ...args: any[]) => any
 
@@ -125,7 +124,7 @@ export const calculateDuration: MathHelperFunction = (
 		allTimedPoints.length === 0
 			? 0
 			: allTimedPoints[allTimedPoints.length - 1].time.getTime() -
-			  allTimedPoints[0].time.getTime()
+				allTimedPoints[0].time.getTime()
 
 	return {
 		startTime: allTimedPoints.length ? allTimedPoints[0].time : null,

--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -3,18 +3,18 @@ import {
 	calculateDuration,
 	calculateElevation,
 	calculateSlopes,
-} from "./math_helpers"
-import { DEFAULT_OPTIONS } from "./options"
-import { ParsedGPX } from "./parsed_gpx"
-import {
+} from './math_helpers'
+import { DEFAULT_OPTIONS } from './options'
+import { ParsedGPX } from './parsed_gpx'
+import type {
+	Extensions,
+	Options,
 	ParsedGPXInputs,
 	Point,
 	Route,
 	Track,
 	Waypoint,
-	Extensions,
-	Options,
-} from "./types"
+} from './types'
 
 /**
  * Converts the given GPX XML to a JavaScript Object with the ability to convert to GeoJSON.
@@ -29,15 +29,15 @@ export const parseGPX = (
 ) => {
 	const parseMethod = (gpxSource: string): Document | null => {
 		// Verify that we are in a browser
-		if (typeof document === "undefined") return null
-		if (typeof window === "undefined") {
+		if (typeof document === 'undefined') return null
+		if (typeof window === 'undefined') {
 			console.error(
-				"window is undefined, try to use the parseGPXWithCustomParser method"
+				'window is undefined, try to use the parseGPXWithCustomParser method'
 			)
 			return null
 		}
 		const domParser = new window.DOMParser()
-		return domParser.parseFromString(gpxSource, "text/xml")
+		return domParser.parseFromString(gpxSource, 'text/xml')
 	}
 	const allOptions = { ...DEFAULT_OPTIONS, ...options }
 	return parseGPXWithCustomParser(gpxSource, parseMethod, allOptions)
@@ -62,14 +62,14 @@ export const parseGPXWithCustomParser = (
 
 	// Verify that the parsed data is present
 	if (parsedSource === null)
-		return [null, new Error("Provided parsing method failed.")]
+		return [null, new Error('Provided parsing method failed.')]
 
 	const output: ParsedGPXInputs = {
 		xml: parsedSource,
 		metadata: {
-			name: "",
-			description: "",
-			time: "",
+			name: '',
+			description: '',
+			time: '',
 			author: null,
 			link: null,
 		},
@@ -78,82 +78,82 @@ export const parseGPXWithCustomParser = (
 		routes: [],
 	}
 
-	const metadata = output.xml.querySelector("metadata")
+	const metadata = output.xml.querySelector('metadata')
 	if (metadata !== null) {
 		// Store the top level elements of the metadata
-		output.metadata.name = getElementValue(metadata, "name")
-		output.metadata.description = getElementValue(metadata, "desc")
-		output.metadata.time = getElementValue(metadata, "time")
+		output.metadata.name = getElementValue(metadata, 'name')
+		output.metadata.description = getElementValue(metadata, 'desc')
+		output.metadata.time = getElementValue(metadata, 'time')
 
 		// Parse and store the tree of data associated with the author
-		const authorElement = metadata.querySelector("author")
+		const authorElement = metadata.querySelector('author')
 		if (authorElement !== null) {
-			const emailElement = authorElement.querySelector("email")
-			const linkElement = authorElement.querySelector("link")
+			const emailElement = authorElement.querySelector('email')
+			const linkElement = authorElement.querySelector('link')
 
 			output.metadata.author = {
-				name: getElementValue(authorElement, "name"),
+				name: getElementValue(authorElement, 'name'),
 				email:
 					emailElement !== null
 						? {
-								id: emailElement.getAttribute("id") ?? "",
+								id: emailElement.getAttribute('id') ?? '',
 								domain:
-									emailElement.getAttribute("domain") ?? "",
-						  }
+									emailElement.getAttribute('domain') ?? '',
+							}
 						: null,
 				link:
 					linkElement !== null
 						? {
-								href: linkElement.getAttribute("href") ?? "",
-								text: getElementValue(linkElement, "text"),
-								type: getElementValue(linkElement, "type"),
-						  }
+								href: linkElement.getAttribute('href') ?? '',
+								text: getElementValue(linkElement, 'text'),
+								type: getElementValue(linkElement, 'type'),
+							}
 						: null,
 			}
 		}
 
 		// Parse and store the link element and its associated data
-		const linkElement = querySelectDirectDescendant(metadata, "link")
+		const linkElement = querySelectDirectDescendant(metadata, 'link')
 		if (linkElement !== null) {
 			output.metadata.link = {
-				href: linkElement.getAttribute("href") ?? "",
-				text: getElementValue(linkElement, "text"),
-				type: getElementValue(linkElement, "type"),
+				href: linkElement.getAttribute('href') ?? '',
+				text: getElementValue(linkElement, 'text'),
+				type: getElementValue(linkElement, 'type'),
 			}
 		}
 	}
 
 	// Parse and store all waypoints
-	const waypoints = Array.from(output.xml.querySelectorAll("wpt"))
+	const waypoints = Array.from(output.xml.querySelectorAll('wpt'))
 	for (const waypoint of waypoints) {
 		const point: Waypoint = {
-			name: getElementValue(waypoint, "name"),
-			symbol: getElementValue(waypoint, "sym"),
-			latitude: parseFloat(waypoint.getAttribute("lat") ?? ""),
-			longitude: parseFloat(waypoint.getAttribute("lon") ?? ""),
+			name: getElementValue(waypoint, 'name'),
+			symbol: getElementValue(waypoint, 'sym'),
+			latitude: parseFloat(waypoint.getAttribute('lat') ?? ''),
+			longitude: parseFloat(waypoint.getAttribute('lon') ?? ''),
 			elevation: null,
-			comment: getElementValue(waypoint, "cmt"),
-			description: getElementValue(waypoint, "desc"),
+			comment: getElementValue(waypoint, 'cmt'),
+			description: getElementValue(waypoint, 'desc'),
 			time: null,
 		}
 
-		const rawElevation = parseFloat(getElementValue(waypoint, "ele") ?? "")
-		point.elevation = isNaN(rawElevation) ? null : rawElevation
+		const rawElevation = parseFloat(getElementValue(waypoint, 'ele') ?? '')
+		point.elevation = Number.isNaN(rawElevation) ? null : rawElevation
 
-		const rawTime = getElementValue(waypoint, "time")
+		const rawTime = getElementValue(waypoint, 'time')
 		point.time = rawTime == null ? null : new Date(rawTime)
 
 		output.waypoints.push(point)
 	}
 
-	const routes = Array.from(output.xml.querySelectorAll("rte"))
+	const routes = Array.from(output.xml.querySelectorAll('rte'))
 	for (const routeElement of routes) {
 		const route: Route = {
-			name: getElementValue(routeElement, "name"),
-			comment: getElementValue(routeElement, "cmt"),
-			description: getElementValue(routeElement, "desc"),
-			src: getElementValue(routeElement, "src"),
-			number: getElementValue(routeElement, "number"),
+			name: getElementValue(routeElement, 'name'),
+			comment: getElementValue(routeElement, 'cmt'),
+			description: getElementValue(routeElement, 'desc'),
+			src: getElementValue(routeElement, 'src'),
+			number: getElementValue(routeElement, 'number'),
 			type: null,
 			link: null,
 			points: [],
@@ -178,36 +178,36 @@ export const parseGPXWithCustomParser = (
 			slopes: [],
 		}
 
-		const type = querySelectDirectDescendant(routeElement, "type")
+		const type = querySelectDirectDescendant(routeElement, 'type')
 		route.type = type?.innerHTML ?? type?.textContent ?? null
 
 		// Parse and store the link and its associated data
-		const linkElement = routeElement.querySelector("link")
+		const linkElement = routeElement.querySelector('link')
 		if (linkElement !== null) {
 			route.link = {
-				href: linkElement.getAttribute("href") ?? "",
-				text: getElementValue(linkElement, "text"),
-				type: getElementValue(linkElement, "type"),
+				href: linkElement.getAttribute('href') ?? '',
+				text: getElementValue(linkElement, 'text'),
+				type: getElementValue(linkElement, 'type'),
 			}
 		}
 
 		// Parse and store all points in the route
-		const routePoints = Array.from(routeElement.querySelectorAll("rtept"))
+		const routePoints = Array.from(routeElement.querySelectorAll('rtept'))
 		for (const routePoint of routePoints) {
 			const point: Point = {
-				latitude: parseFloat(routePoint.getAttribute("lat") ?? ""),
-				longitude: parseFloat(routePoint.getAttribute("lon") ?? ""),
+				latitude: parseFloat(routePoint.getAttribute('lat') ?? ''),
+				longitude: parseFloat(routePoint.getAttribute('lon') ?? ''),
 				elevation: null,
 				time: null,
 				extensions: null,
 			}
 
 			const rawElevation = parseFloat(
-				getElementValue(routePoint, "ele") ?? ""
+				getElementValue(routePoint, 'ele') ?? ''
 			)
-			point.elevation = isNaN(rawElevation) ? null : rawElevation
+			point.elevation = Number.isNaN(rawElevation) ? null : rawElevation
 
-			const rawTime = getElementValue(routePoint, "time")
+			const rawTime = getElementValue(routePoint, 'time')
 			point.time = rawTime == null ? null : new Date(rawTime)
 
 			route.points.push(point)
@@ -225,14 +225,14 @@ export const parseGPXWithCustomParser = (
 		output.routes.push(route)
 	}
 
-	const tracks = Array.from(output.xml.querySelectorAll("trk"))
+	const tracks = Array.from(output.xml.querySelectorAll('trk'))
 	for (const trackElement of tracks) {
 		const track: Track = {
-			name: getElementValue(trackElement, "name"),
-			comment: getElementValue(trackElement, "cmt"),
-			description: getElementValue(trackElement, "desc"),
-			src: getElementValue(trackElement, "src"),
-			number: getElementValue(trackElement, "number"),
+			name: getElementValue(trackElement, 'name'),
+			comment: getElementValue(trackElement, 'cmt'),
+			description: getElementValue(trackElement, 'desc'),
+			src: getElementValue(trackElement, 'src'),
+			number: getElementValue(trackElement, 'number'),
 			type: null,
 			link: null,
 			points: [],
@@ -257,32 +257,32 @@ export const parseGPXWithCustomParser = (
 			slopes: [],
 		}
 
-		const type = querySelectDirectDescendant(trackElement, "type")
+		const type = querySelectDirectDescendant(trackElement, 'type')
 		track.type = type?.innerHTML ?? type?.textContent ?? null
 
 		// Parse and store the link and its associated data
-		const linkElement = trackElement.querySelector("link")
+		const linkElement = trackElement.querySelector('link')
 		if (linkElement !== null) {
 			track.link = {
-				href: linkElement.getAttribute("href") ?? "",
-				text: getElementValue(linkElement, "text"),
-				type: getElementValue(linkElement, "type"),
+				href: linkElement.getAttribute('href') ?? '',
+				text: getElementValue(linkElement, 'text'),
+				type: getElementValue(linkElement, 'type'),
 			}
 		}
 
 		// Parse and store all track points
-		const trackPoints = Array.from(trackElement.querySelectorAll("trkpt"))
+		const trackPoints = Array.from(trackElement.querySelectorAll('trkpt'))
 		for (const trackPoint of trackPoints) {
 			const point: Point = {
-				latitude: parseFloat(trackPoint.getAttribute("lat") ?? ""),
-				longitude: parseFloat(trackPoint.getAttribute("lon") ?? ""),
+				latitude: parseFloat(trackPoint.getAttribute('lat') ?? ''),
+				longitude: parseFloat(trackPoint.getAttribute('lon') ?? ''),
 				elevation: null,
 				time: null,
 				extensions: null,
 			}
 
 			// Parse any extensions and store them in an object
-			const extensionsElement = trackPoint.querySelector("extensions")
+			const extensionsElement = trackPoint.querySelector('extensions')
 			if (extensionsElement !== null) {
 				let extensions: Extensions = {}
 				extensions = parseExtensions(
@@ -294,11 +294,11 @@ export const parseGPXWithCustomParser = (
 			}
 
 			const rawElevation = parseFloat(
-				getElementValue(trackPoint, "ele") ?? ""
+				getElementValue(trackPoint, 'ele') ?? ''
 			)
-			point.elevation = isNaN(rawElevation) ? null : rawElevation
+			point.elevation = Number.isNaN(rawElevation) ? null : rawElevation
 
-			const rawTime = getElementValue(trackPoint, "time")
+			const rawTime = getElementValue(trackPoint, 'time')
 			point.time = rawTime == null ? null : new Date(rawTime)
 
 			track.points.push(point)
@@ -340,7 +340,7 @@ const parseExtensions = (
 				child.childNodes[0].textContent
 			) {
 				const textContent = child.childNodes[0].textContent.trim()
-				const value = isNaN(+textContent)
+				const value = Number.isNaN(+textContent)
 					? textContent
 					: parseFloat(textContent)
 				extensions[tagName] = value
@@ -389,12 +389,12 @@ const querySelectDirectDescendant = (
 		// Find the first direct matching direct descendent
 		const result = parent.querySelector(`:scope > ${tag}`)
 		return result
-	} catch (e) {
+	} catch (_e) {
 		// Handle non-browser or older environments that don't support :scope
 		if (parent.childNodes) {
 			return (
 				(Array.from(parent.childNodes) as Element[]).find(
-					(element) => element.tagName == tag
+					(element) => element.tagName === tag
 				) ?? null
 			)
 		} else return null
@@ -403,7 +403,7 @@ const querySelectDirectDescendant = (
 
 export const deleteNullFields = <T>(object: T) => {
 	// Return non-object values as-is
-	if (typeof object !== "object" || object === null || object === undefined) {
+	if (typeof object !== 'object' || object === null || object === undefined) {
 		return
 	}
 
@@ -415,7 +415,7 @@ export const deleteNullFields = <T>(object: T) => {
 
 	// Recursively remove null fields from object
 	for (const [key, value] of Object.entries(object)) {
-		if (value == null || value == undefined) {
+		if (value == null || value === undefined) {
 			delete (object as { [key: string]: any })[key]
 		} else {
 			deleteNullFields(value)

--- a/lib/parsed_gpx.ts
+++ b/lib/parsed_gpx.ts
@@ -1,4 +1,7 @@
-import {
+import type { MathHelperFunction } from './math_helpers'
+
+import { deleteNullFields } from './parse'
+import type {
 	Feature,
 	GeoJSON,
 	MetaData,
@@ -8,10 +11,7 @@ import {
 	Track,
 	Waypoint,
 	WaypointFeature,
-} from "./types"
-
-import { deleteNullFields } from "./parse"
-import { MathHelperFunction } from "./math_helpers"
+} from './types'
 
 /**
  * Represents a parsed GPX object.
@@ -44,7 +44,7 @@ export class ParsedGPX {
 	 */
 	toGeoJSON() {
 		const GeoJSON: GeoJSON = {
-			type: "FeatureCollection",
+			type: 'FeatureCollection',
 			features: [],
 			properties: this.metadata,
 		}
@@ -63,8 +63,8 @@ export class ParsedGPX {
 			} = track
 
 			const feature: Feature = {
-				type: "Feature",
-				geometry: { type: "LineString", coordinates: [] },
+				type: 'Feature',
+				geometry: { type: 'LineString', coordinates: [] },
 				properties: {
 					name,
 					comment,
@@ -105,9 +105,9 @@ export class ParsedGPX {
 			} = waypoint
 
 			const feature: WaypointFeature = {
-				type: "Feature",
+				type: 'Feature',
 				geometry: {
-					type: "Point",
+					type: 'Point',
 					coordinates: [longitude, latitude, elevation],
 				},
 				properties: { name, symbol, comment, description },
@@ -128,11 +128,10 @@ export class ParsedGPX {
 	): ReturnType<MathHelperFunction> {
 		// Ensure that the track index is valid
 		if (trackIndex < 0 || trackIndex >= this.tracks.length) {
-			console.error("The track index is out of bounds.")
+			console.error('The track index is out of bounds.')
 			return
 		}
 
-		// @ts-ignore: A spread argument must either have a tuple type or be passed to a rest parameter.
 		try {
 			return func(this.tracks[trackIndex].points, ...args)
 		} catch (error) {
@@ -150,11 +149,10 @@ export class ParsedGPX {
 	): ReturnType<MathHelperFunction> {
 		// Ensure that the route index is valid
 		if (routeIndex < 0 || routeIndex >= this.routes.length) {
-			console.error("The route index is out of bounds.")
+			console.error('The route index is out of bounds.')
 			return
 		}
 
-		// @ts-ignore: A spread argument must either have a tuple type or be passed to a rest parameter.
 		try {
 			return func(this.routes[routeIndex].points, ...args)
 		} catch (error) {

--- a/lib/stringify.ts
+++ b/lib/stringify.ts
@@ -1,8 +1,8 @@
-import { ParsedGPX } from "./parsed_gpx";
-import { Extensions } from "./types";
+import type { ParsedGPX } from './parsed_gpx'
+import type { Extensions } from './types'
 
 interface XMLSerializationStrategy {
-    serializeToString(doc: Document): string;
+	serializeToString(doc: Document): string
 }
 
 /**
@@ -12,78 +12,81 @@ interface XMLSerializationStrategy {
  *   If not specified, a default XMLSerializer instance will be created.
  * @returns a serialized XML string in the GPX format
  */
-export function stringifyGPX(gpx: ParsedGPX, customXmlSerializer?: XMLSerializationStrategy): string {
-    const doc = gpx.xml.implementation.createDocument(GPX_NS, "gpx");
-    doc.documentElement.setAttribute('version', '1.1');
-    doc.documentElement.setAttribute('creator', 'gpxjs');
-    const mapper = new XmlMapper(doc);
-    mapper.mapObject(GPX_MAPPING, gpx, doc.documentElement);
-    const serializer = customXmlSerializer ?? new XMLSerializer();
-    return serializer.serializeToString(doc);
+export function stringifyGPX(
+	gpx: ParsedGPX,
+	customXmlSerializer?: XMLSerializationStrategy
+): string {
+	const doc = gpx.xml.implementation.createDocument(GPX_NS, 'gpx')
+	doc.documentElement.setAttribute('version', '1.1')
+	doc.documentElement.setAttribute('creator', 'gpxjs')
+	const mapper = new XmlMapper(doc)
+	mapper.mapObject(GPX_MAPPING, gpx, doc.documentElement)
+	const serializer = customXmlSerializer ?? new XMLSerializer()
+	return serializer.serializeToString(doc)
 }
 
 /****
  * Implementation Details
- * 
+ *
  * We provide a system for specifying the mapping from a ParsedGPX data
  * structure to a corresponding XML structure, without having to write code for
  * each field.
  ****/
 
 // GPX XML Namespace
-const GPX_NS = 'http://www.topografix.com/GPX/1/1';
+const GPX_NS = 'http://www.topografix.com/GPX/1/1'
 
 // Special properties used in field mapping.  See documentation in FieldMapping.
-const EXPR_PROPERTY = '$expr';
-const FOR_PROPERTY = '$for';
-const FUNC_PROPERTY = '$func';
+const EXPR_PROPERTY = '$expr'
+const FOR_PROPERTY = '$for'
+const FUNC_PROPERTY = '$func'
 
 /**
  * Specifies the XML mapping for an object.
  */
 type ObjectMapping = {
-    /**
-     * Each key represents an XML element or attribute in the output value,
-     * while the associated value specifies how that content of the element is
-     * produced from the source data.
-     * 
-     * To specify an attribute, use a key like '@attribute_name'.  Otherwise,
-     * the key specifies an element name.
-     * 
-     * If the key-value is a string, it specifies the corresponding field in
-     * the source object that will be read to fill the element value.  If the
-     * key-value is '=', then the element name will be used as the field name.
-     * 
-     * If the key-value specifies a nested ObjectMapping, then that mapping will
-     * be used to recursively generate additional sub-elements in the mapping.
-     * That mapping can be tweaked with a few specific fields.  See FieldMapping
-     * for more details.
-     */
-    [key: string]: string | ObjectMapping | FieldMapping
+	/**
+	 * Each key represents an XML element or attribute in the output value,
+	 * while the associated value specifies how that content of the element is
+	 * produced from the source data.
+	 *
+	 * To specify an attribute, use a key like '@attribute_name'.  Otherwise,
+	 * the key specifies an element name.
+	 *
+	 * If the key-value is a string, it specifies the corresponding field in
+	 * the source object that will be read to fill the element value.  If the
+	 * key-value is '=', then the element name will be used as the field name.
+	 *
+	 * If the key-value specifies a nested ObjectMapping, then that mapping will
+	 * be used to recursively generate additional sub-elements in the mapping.
+	 * That mapping can be tweaked with a few specific fields.  See FieldMapping
+	 * for more details.
+	 */
+	[key: string]: string | ObjectMapping | FieldMapping
 }
 
 /**
  * Specifies special behavior when mapping a sub-object.
  */
 type FieldMapping = {
-    /**
-     * Normally, the element name is used to determine the corresponding object
-     * field name to use when looking up the object value used in a mapping.
-     * The $expr property can be used to specify a different field name to use.
-     */
-    $expr?: string
-    /**
-     * For repeated elements generated from an array, specify this field with
-     * the corresponding 
-     */
-    $for?: ObjectMapping
-    /**
-     * For complex mappings, specify a function with the following signature:
-     *   (doc: Document, srcObj: any, dstElem: Element)
-     * This function will be called, allowing one to specify arbitrary mapping
-     * behavior.
-     */
-    $func?: Function
+	/**
+	 * Normally, the element name is used to determine the corresponding object
+	 * field name to use when looking up the object value used in a mapping.
+	 * The $expr property can be used to specify a different field name to use.
+	 */
+	$expr?: string
+	/**
+	 * For repeated elements generated from an array, specify this field with
+	 * the corresponding
+	 */
+	$for?: ObjectMapping
+	/**
+	 * For complex mappings, specify a function with the following signature:
+	 *   (doc: Document, srcObj: any, dstElem: Element)
+	 * This function will be called, allowing one to specify arbitrary mapping
+	 * behavior.
+	 */
+	$func?: Function
 }
 
 /****
@@ -91,192 +94,204 @@ type FieldMapping = {
  ****/
 
 const LINK_MAPPING: ObjectMapping = {
-    "@href": '=',
-    text: '=',
-    type: '='
+	'@href': '=',
+	text: '=',
+	type: '=',
 }
 
 // We need a special mapping function to handle the arbitrary data in an
 // Extensions object.
-function ExtensionsMapping(doc: Document, srcObj: Extensions, dstElem: Element) {
-    for (const key in srcObj) {
-        const elem = doc.createElementNS(GPX_NS, key);
-        dstElem.append(elem);
-        const value = srcObj[key];
-        if (typeof value === 'object') {
-            ExtensionsMapping(doc, value, elem);
-        } else {
-            const node = doc.createTextNode(value.toString());
-            elem.append(node);
-        }
-    }
+function ExtensionsMapping(
+	doc: Document,
+	srcObj: Extensions,
+	dstElem: Element
+) {
+	for (const key in srcObj) {
+		const elem = doc.createElementNS(GPX_NS, key)
+		dstElem.append(elem)
+		const value = srcObj[key]
+		if (typeof value === 'object') {
+			ExtensionsMapping(doc, value, elem)
+		} else {
+			const node = doc.createTextNode(value.toString())
+			elem.append(node)
+		}
+	}
 }
 
 const POINT_MAPPING: ObjectMapping = {
-    '@lat': 'latitude',
-    '@lon': 'longitude',
-    ele: 'elevation',
-    time: '=',
-    extensions: {
-        $func: ExtensionsMapping
-    }
+	'@lat': 'latitude',
+	'@lon': 'longitude',
+	ele: 'elevation',
+	time: '=',
+	extensions: {
+		$func: ExtensionsMapping,
+	},
 }
 
 const GPX_MAPPING: ObjectMapping = {
-    metadata: {
-        name: '=',
-        desc: 'description',
-        author: {
-            name: '=',
-            email: {
-                '@id': '=',
-                '@domain': '='
-            },
-            link: LINK_MAPPING
-        },
-        link: LINK_MAPPING,
-        time: '='
-    },
-    wpt: {
-        $expr: 'waypoints',
-        $for: {
-            '@lat': 'latitude',
-            '@lon': 'longitude',
-            name: '=',
-            desc: 'description',
-            ele: 'elevation',
-            time: '=',
-            cmt: 'comment'
-        }
-    },
-    trk: {
-        $expr: 'tracks',
-        $for: {
-            name: '=',
-            cmt: 'comment',
-            desc: 'description',
-            src: '=',
-            number: '=',
-            link: LINK_MAPPING,
-            type: '=',
-            trkseg: {
-                $expr: '.',
-                trkpt: {
-                    $expr: 'points',
-                    $for: POINT_MAPPING
-                },
-            },
-        },
-    },
-    rte: {
-        $expr: 'routes',
-        $for: {
-            name: '=',
-            cmt: 'comment',
-            desc: 'description',
-            src: '=',
-            number: '=',
-            link: LINK_MAPPING,
-            type: '=',
-            rtept: {
-                $expr: 'points',
-                $for: POINT_MAPPING
-            }
-        }
-    }
-};
+	metadata: {
+		name: '=',
+		desc: 'description',
+		author: {
+			name: '=',
+			email: {
+				'@id': '=',
+				'@domain': '=',
+			},
+			link: LINK_MAPPING,
+		},
+		link: LINK_MAPPING,
+		time: '=',
+	},
+	wpt: {
+		$expr: 'waypoints',
+		$for: {
+			'@lat': 'latitude',
+			'@lon': 'longitude',
+			name: '=',
+			desc: 'description',
+			ele: 'elevation',
+			time: '=',
+			cmt: 'comment',
+		},
+	},
+	trk: {
+		$expr: 'tracks',
+		$for: {
+			name: '=',
+			cmt: 'comment',
+			desc: 'description',
+			src: '=',
+			number: '=',
+			link: LINK_MAPPING,
+			type: '=',
+			trkseg: {
+				$expr: '.',
+				trkpt: {
+					$expr: 'points',
+					$for: POINT_MAPPING,
+				},
+			},
+		},
+	},
+	rte: {
+		$expr: 'routes',
+		$for: {
+			name: '=',
+			cmt: 'comment',
+			desc: 'description',
+			src: '=',
+			number: '=',
+			link: LINK_MAPPING,
+			type: '=',
+			rtept: {
+				$expr: 'points',
+				$for: POINT_MAPPING,
+			},
+		},
+	},
+}
 
 class XmlMapper {
-    private doc: Document;
-    constructor(doc: Document) {
-        this.doc = doc;
-    }
+	private doc: Document
+	constructor(doc: Document) {
+		this.doc = doc
+	}
 
-    /**
-     * Generate XML attributes and elements using the given mapping.
-     */
-    mapObject(objectMapping: ObjectMapping, srcObj: any, dstElem: Element) {
-        for (const field in objectMapping) {
-            if (field === EXPR_PROPERTY) {
-                continue;
-            }
-            this.mapField(field, objectMapping[field], srcObj, dstElem);
-        }
-    }
+	/**
+	 * Generate XML attributes and elements using the given mapping.
+	 */
+	mapObject(objectMapping: ObjectMapping, srcObj: any, dstElem: Element) {
+		for (const field in objectMapping) {
+			if (field === EXPR_PROPERTY) {
+				continue
+			}
+			this.mapField(field, objectMapping[field], srcObj, dstElem)
+		}
+	}
 
-    /**
-     * Generate XML elements and attributes for the specified field.
-     */
-    mapField(
-        fieldExpr: string,
-        mapping: string | ObjectMapping | FieldMapping,
-        srcObj: any,
-        dstElem: Element
-    ) {
-        const isAttribute = fieldExpr.startsWith('@');
-        const fieldName = isAttribute ? fieldExpr.substring(1) : fieldExpr;
+	/**
+	 * Generate XML elements and attributes for the specified field.
+	 */
+	mapField(
+		fieldExpr: string,
+		mapping: string | ObjectMapping | FieldMapping,
+		srcObj: any,
+		dstElem: Element
+	) {
+		const isAttribute = fieldExpr.startsWith('@')
+		const fieldName = isAttribute ? fieldExpr.substring(1) : fieldExpr
 
-        if (typeof mapping === "object") {
-            const fieldMapping = mapping as FieldMapping;
-            const fieldValue = this.evalExpr(srcObj, fieldMapping[EXPR_PROPERTY] ?? '=', fieldName);
-            if (fieldValue == null) {
-                return;
-            }
-            const forMapping = fieldMapping[FOR_PROPERTY];
-            if (forMapping) {
-                for (const value of fieldValue) {
-                    const elem = this.doc.createElementNS(GPX_NS, fieldName);
-                    dstElem.append(elem);
-                    this.mapObject(forMapping, value, elem);
-                }
-            } else {
-                const elem = this.doc.createElementNS(GPX_NS, fieldName);
-                dstElem.append(elem);
+		if (typeof mapping === 'object') {
+			const fieldMapping = mapping as FieldMapping
+			const fieldValue = this.evalExpr(
+				srcObj,
+				fieldMapping[EXPR_PROPERTY] ?? '=',
+				fieldName
+			)
+			if (fieldValue == null) {
+				return
+			}
+			const forMapping = fieldMapping[FOR_PROPERTY]
+			if (forMapping) {
+				for (const value of fieldValue) {
+					const elem = this.doc.createElementNS(GPX_NS, fieldName)
+					dstElem.append(elem)
+					this.mapObject(forMapping, value, elem)
+				}
+			} else {
+				const elem = this.doc.createElementNS(GPX_NS, fieldName)
+				dstElem.append(elem)
 
-                const funcMapping = fieldMapping[FUNC_PROPERTY];
-                if (funcMapping) {
-                    funcMapping(this.doc, fieldValue, elem);
-                } else {
-                    this.mapObject(mapping as ObjectMapping, fieldValue, elem);
-                }
-            }
-        } else if (typeof mapping === "string") {
-            const value = this.evalExpr(srcObj, mapping, fieldName);
-            if (value == null) {
-                return;
-            }
+				const funcMapping = fieldMapping[FUNC_PROPERTY]
+				if (funcMapping) {
+					funcMapping(this.doc, fieldValue, elem)
+				} else {
+					this.mapObject(mapping as ObjectMapping, fieldValue, elem)
+				}
+			}
+		} else if (typeof mapping === 'string') {
+			const value = this.evalExpr(srcObj, mapping, fieldName)
+			if (value == null) {
+				return
+			}
 
-            if (isAttribute) {
-                dstElem.setAttribute(fieldName, value);
-            } else {
-                const valueElem = this.doc.createElementNS(GPX_NS, fieldName);
-                dstElem.append(valueElem);
-                const node = this.doc.createTextNode(value);
-                valueElem.append(node);
-            }
-        } else {
-            throw new Error(`Unsupported field mapping: ${mapping}`)
-        }
-    }
+			if (isAttribute) {
+				dstElem.setAttribute(fieldName, value)
+			} else {
+				const valueElem = this.doc.createElementNS(GPX_NS, fieldName)
+				dstElem.append(valueElem)
+				const node = this.doc.createTextNode(value)
+				valueElem.append(node)
+			}
+		} else {
+			throw new Error(`Unsupported field mapping: ${mapping}`)
+		}
+	}
 
-    /**
-     * Evalutes a field expression for the specified object.  If the expression
-     * equals `=`, then the specified `fieldName` will be used.
-     */
-    evalExpr(srcObj: any, expr: string, fieldName: string) {
-        let property = expr;
-        if (expr === '.') {
-            return srcObj;
-        } else if (expr === '=') {
-            property = fieldName;
-        }
-        const value = srcObj[property];
+	/**
+	 * Evalutes a field expression for the specified object.  If the expression
+	 * equals `=`, then the specified `fieldName` will be used.
+	 */
+	evalExpr(srcObj: any, expr: string, fieldName: string) {
+		let property = expr
+		if (expr === '.') {
+			return srcObj
+		} else if (expr === '=') {
+			property = fieldName
+		}
+		const value = srcObj[property]
 
-        // Special handling for Date objects.
-        if (value != null && typeof value === 'object' && fieldName === 'time') {
-            return value.toISOString();
-        }
+		// Special handling for Date objects.
+		if (
+			value != null &&
+			typeof value === 'object' &&
+			fieldName === 'time'
+		) {
+			return value.toISOString()
+		}
 
-        return value;
-    }
+		return value
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.1.0",
 			"license": "MIT",
 			"devDependencies": {
+				"@biomejs/biome": "^2.5.2",
 				"@types/node": "^24.13.2",
 				"@vitest/browser": "^4.1.9",
 				"@vitest/browser-playwright": "^4.1.9",
@@ -18,6 +19,169 @@
 				"vite-plugin-dts": "^5.0.3",
 				"vitest": "^4.1.9",
 				"xmldom-qsa": "^1.1.3"
+			}
+		},
+		"node_modules/@biomejs/biome": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.2.tgz",
+			"integrity": "sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.5.2",
+				"@biomejs/cli-darwin-x64": "2.5.2",
+				"@biomejs/cli-linux-arm64": "2.5.2",
+				"@biomejs/cli-linux-arm64-musl": "2.5.2",
+				"@biomejs/cli-linux-x64": "2.5.2",
+				"@biomejs/cli-linux-x64-musl": "2.5.2",
+				"@biomejs/cli-win32-arm64": "2.5.2",
+				"@biomejs/cli-win32-x64": "2.5.2"
+			}
+		},
+		"node_modules/@biomejs/cli-darwin-arm64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.2.tgz",
+			"integrity": "sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-darwin-x64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.2.tgz",
+			"integrity": "sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.2.tgz",
+			"integrity": "sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64-musl": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.2.tgz",
+			"integrity": "sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.2.tgz",
+			"integrity": "sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64-musl": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.2.tgz",
+			"integrity": "sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-arm64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.2.tgz",
+			"integrity": "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-x64": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.2.tgz",
+			"integrity": "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
 			}
 		},
 		"node_modules/@blazediff/core": {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
 		"apple-watch",
 		"gps"
 	],
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"main": "./dist/gpxjs.umd.cjs",
 	"module": "./dist/gpxjs.js",
 	"types": "./dist/index.d.ts",
@@ -39,9 +37,13 @@
 		"watch": "vite build --watch",
 		"pack-test": "npm pack --dry-run",
 		"preview": "vite preview",
-		"test": "vitest"
+		"test": "vitest",
+		"lint": "biome check .",
+		"lint:fix": "biome check --write .",
+		"format": "biome format --write ."
 	},
 	"devDependencies": {
+		"@biomejs/biome": "^2.5.2",
 		"@types/node": "^24.13.2",
 		"@vitest/browser": "^4.1.9",
 		"@vitest/browser-playwright": "^4.1.9",
@@ -51,11 +53,5 @@
 		"vite-plugin-dts": "^5.0.3",
 		"vitest": "^4.1.9",
 		"xmldom-qsa": "^1.1.3"
-	},
-	"prettier": {
-		"trailingComma": "es5",
-		"tabWidth": 4,
-		"semi": false,
-		"useTabs": true
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
-import { parseGPX, parseGPXWithCustomParser } from "../lib"
-import { DOMParser } from "xmldom-qsa"
+import { DOMParser } from 'xmldom-qsa'
+import { parseGPX, parseGPXWithCustomParser } from '../lib'
 
-fetch("./src/test_files/test.gpx")
+fetch('./src/test_files/test.gpx')
 	.then((response) => {
 		if (!response.ok) {
-			throw new Error("Failed to fetch the file")
+			throw new Error('Failed to fetch the file')
 		}
 		return response.text()
 	})
@@ -13,11 +13,11 @@ fetch("./src/test_files/test.gpx")
 		testNonBrowserParser(textData)
 	})
 	.catch((error) => {
-		console.error("Error:", error)
+		console.error('Error:', error)
 	})
 
 const testBrowserParser = (textData: string) => {
-	console.log("\nBROWSER MODE")
+	console.log('\nBROWSER MODE')
 	let startTime = performance.now()
 
 	const [parsedGPX, error] = parseGPX(textData)
@@ -26,7 +26,7 @@ const testBrowserParser = (textData: string) => {
 	if (error) throw error
 
 	let endTime = performance.now()
-	console.log("Execution time:", endTime - startTime, "ms")
+	console.log('Execution time:', endTime - startTime, 'ms')
 	console.log(parsedGPX)
 
 	startTime = performance.now()
@@ -34,25 +34,25 @@ const testBrowserParser = (textData: string) => {
 	const GeoJSON = parsedGPX.toGeoJSON()
 
 	endTime = performance.now()
-	console.log("Execution time:", endTime - startTime, "ms")
+	console.log('Execution time:', endTime - startTime, 'ms')
 	console.log(GeoJSON)
 }
 
 const testNonBrowserParser = (textData: string) => {
-	console.log("\nNONBROWSER MODE")
+	console.log('\nNONBROWSER MODE')
 	let startTime = performance.now()
 
 	const [parsedGPX, error] = parseGPXWithCustomParser(
 		textData,
 		(txt: string): Document | null =>
-			new DOMParser().parseFromString(txt, "text/xml")
+			new DOMParser().parseFromString(txt, 'text/xml')
 	)
 
 	// Verify that the parsing was successful
 	if (error) throw error
 
 	let endTime = performance.now()
-	console.log("Execution time:", endTime - startTime, "ms")
+	console.log('Execution time:', endTime - startTime, 'ms')
 	console.log(parsedGPX)
 
 	startTime = performance.now()
@@ -60,6 +60,6 @@ const testNonBrowserParser = (textData: string) => {
 	const GeoJSON = parsedGPX.toGeoJSON()
 
 	endTime = performance.now()
-	console.log("Execution time:", endTime - startTime, "ms")
+	console.log('Execution time:', endTime - startTime, 'ms')
 	console.log(GeoJSON)
 }

--- a/test/helpers.spec.js
+++ b/test/helpers.spec.js
@@ -1,24 +1,30 @@
-import { test } from "vitest"
+import { test } from 'vitest'
 
-import { parseGPX, calculateDistance, calculateDuration, calculateElevation, calculateSlopes } from "../lib/index"
+import {
+	calculateDistance,
+	calculateDuration,
+	calculateElevation,
+	calculateSlopes,
+	parseGPX,
+} from '../lib/index'
 
-import { testGPXFile } from "./test-gpx-file"
+import { testGPXFile } from './test-gpx-file'
 
-test("All applied functions produce outputs without errors.", () => {
-    const [parsedGPX, error] = parseGPX(testGPXFile)
+test('All applied functions produce outputs without errors.', () => {
+	const [parsedGPX, error] = parseGPX(testGPXFile)
 
-    // Verify that the parsing was successful
-    if (error) throw error
+	// Verify that the parsing was successful
+	if (error) throw error
 
-    // Apply all functions to the first track
-    const tdist = parsedGPX.applyToTrack(0, calculateDistance)
-    parsedGPX.applyToTrack(0, calculateDuration)
-    parsedGPX.applyToTrack(0, calculateElevation)
-    parsedGPX.applyToTrack(0, calculateSlopes, tdist.cumulative)
+	// Apply all functions to the first track
+	const tdist = parsedGPX.applyToTrack(0, calculateDistance)
+	parsedGPX.applyToTrack(0, calculateDuration)
+	parsedGPX.applyToTrack(0, calculateElevation)
+	parsedGPX.applyToTrack(0, calculateSlopes, tdist.cumulative)
 
-    // Apply all functions to the first route
-    const rdist = parsedGPX.applyToRoute(0, calculateDistance)
-    parsedGPX.applyToRoute(0, calculateDuration)
-    parsedGPX.applyToRoute(0, calculateElevation)
-    parsedGPX.applyToRoute(0, calculateSlopes, rdist.cumulative)
+	// Apply all functions to the first route
+	const rdist = parsedGPX.applyToRoute(0, calculateDistance)
+	parsedGPX.applyToRoute(0, calculateDuration)
+	parsedGPX.applyToRoute(0, calculateElevation)
+	parsedGPX.applyToRoute(0, calculateSlopes, rdist.cumulative)
 })

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -1,9 +1,15 @@
-import { expect, test, assertType } from "vitest"
+import { assertType, expect, test } from 'vitest'
 
-import { DOMParser } from "xmldom-qsa"
-import { parseGPX, parseGPXWithCustomParser } from "../lib/index"
+import { DOMParser } from 'xmldom-qsa'
+import { parseGPX, parseGPXWithCustomParser } from '../lib/index'
 
-import { testGPXFile, expectedMetadata, expectedWaypoint, expectedRoute, expectedTrack } from "./test-gpx-file"
+import {
+	expectedMetadata,
+	expectedRoute,
+	expectedTrack,
+	expectedWaypoint,
+	testGPXFile,
+} from './test-gpx-file'
 
 // TODO test GeoJSON, benchmarks
 
@@ -12,69 +18,69 @@ import { testGPXFile, expectedMetadata, expectedWaypoint, expectedRoute, expecte
 // Parse some times as dates and some as strings
 // Some items match abbreviations, some don't
 
-test("Default parsing returns expected result", () => {
+test('Default parsing returns expected result', () => {
 	const [parsedGPX, error] = parseGPX(testGPXFile)
 
 	// Verify that the parsing was successful
 	if (error) throw error
 
-    assertType<XMLDocument>(parsedGPX.xml)
+	assertType < XMLDocument > parsedGPX.xml
 
-    // Test metadata from test file
-    expect(expectedMetadata).toStrictEqual(parsedGPX.metadata)  
+	// Test metadata from test file
+	expect(expectedMetadata).toStrictEqual(parsedGPX.metadata)
 
-    // Test waypoint data
-    const waypoint = parsedGPX.waypoints[0]
+	// Test waypoint data
+	const waypoint = parsedGPX.waypoints[0]
 
-    expect(waypoint).not.toBeNull()
-    expect(waypoint).toStrictEqual(expectedWaypoint)  
+	expect(waypoint).not.toBeNull()
+	expect(waypoint).toStrictEqual(expectedWaypoint)
 
-    // Test track information
-    const track = parsedGPX.tracks[0]
+	// Test track information
+	const track = parsedGPX.tracks[0]
 
-    expect(track).not.toBeNull()
-    expect(track).toStrictEqual(expectedTrack)  
-    
-    // Test route information
-    const route = parsedGPX.routes[0]
+	expect(track).not.toBeNull()
+	expect(track).toStrictEqual(expectedTrack)
 
-    expect(route).not.toBeNull()
-    expect(route).toStrictEqual(expectedRoute)  
+	// Test route information
+	const route = parsedGPX.routes[0]
+
+	expect(route).not.toBeNull()
+	expect(route).toStrictEqual(expectedRoute)
 })
 
-test("Non-browser parsing returns expected result", () => {
-    const customParseMethod = (txt)=> {
-        return new DOMParser().parseFromString(txt, "text/xml")
-    }
+test('Non-browser parsing returns expected result', () => {
+	const customParseMethod = (txt) => {
+		return new DOMParser().parseFromString(txt, 'text/xml')
+	}
 
-    const [parsedGPX, error] = parseGPXWithCustomParser(
-        testGPXFile,
-        customParseMethod
-    )
+	const [parsedGPX, error] = parseGPXWithCustomParser(
+		testGPXFile,
+		customParseMethod
+	)
 
 	// Verify that the parsing was successful
 	if (error) throw error
 
-    assertType<XMLDocument>(parsedGPX.xml)
+	assertType < XMLDocument > parsedGPX.xml
 
-    // Test metadata from test file
-    expect(expectedMetadata).toStrictEqual(parsedGPX.metadata)  
+	// Test metadata from test file
+	expect(expectedMetadata).toStrictEqual(parsedGPX.metadata)
 
-    // Test waypoint data
-    const waypoint = parsedGPX.waypoints[0]
+	// Test waypoint data
+	const waypoint = parsedGPX.waypoints[0]
 
-    expect(waypoint).not.toBeNull()
-    expect(waypoint).toStrictEqual(expectedWaypoint)  
+	expect(waypoint).not.toBeNull()
+	expect(waypoint).toStrictEqual(expectedWaypoint)
 
-    // Test track information
-    const track = parsedGPX.tracks[0]
+	// Test track information
+	const track = parsedGPX.tracks[0]
 
-    expect(track).not.toBeNull()
-    expect(track).toStrictEqual(expectedTrack)  
-    
-    // Test route information
-    const route = parsedGPX.routes[0]
+	expect(track).not.toBeNull()
+	expect(track).toStrictEqual(expectedTrack)
 
-    expect(route).not.toBeNull()
-    expect(route).toStrictEqual(expectedRoute)  
+	// Test route information
+	const route = parsedGPX.routes[0]
+
+	expect(route).not.toBeNull()
+	expect(route).toStrictEqual(expectedRoute)
 })

--- a/test/stringify.spec.js
+++ b/test/stringify.spec.js
@@ -1,27 +1,26 @@
-import { expect, test, assertType, describe } from "vitest"
+import { describe, expect, test } from 'vitest'
 
-import { XMLSerializer as QsaXMLSerializer } from "xmldom-qsa"
-import { parseGPX } from "../lib/index";
-import { stringifyGPX } from "../lib/stringify";
+import { XMLSerializer as QsaXMLSerializer } from 'xmldom-qsa'
+import { parseGPX } from '../lib/index'
+import { stringifyGPX } from '../lib/stringify'
 
-import { testGPXFile } from "./test-gpx-file"
+import { testGPXFile } from './test-gpx-file'
 
-describe("stringfy", () => {
-  test("converts ParsedGPX to string", () => {
-    const [gpx, error] = parseGPX(testGPXFile);
-    const xml = stringifyGPX(gpx);
-    expect(prettyPrintXml(xml)).toEqual(prettyPrintXml(EXPECTED_XML));
-  })
+describe('stringfy', () => {
+	test('converts ParsedGPX to string', () => {
+		const [gpx, _error] = parseGPX(testGPXFile)
+		const xml = stringifyGPX(gpx)
+		expect(prettyPrintXml(xml)).toEqual(prettyPrintXml(EXPECTED_XML))
+	})
 
-  test("converts ParsedGPX to string with custom XMLSerializer", () => {
-    const [gpx, error] = parseGPX(testGPXFile);
-    const xml = stringifyGPX(gpx, new QsaXMLSerializer());
-    expect(prettyPrintXml(xml)).toEqual(prettyPrintXml(EXPECTED_XML));
-  })
-});
+	test('converts ParsedGPX to string with custom XMLSerializer', () => {
+		const [gpx, _error] = parseGPX(testGPXFile)
+		const xml = stringifyGPX(gpx, new QsaXMLSerializer())
+		expect(prettyPrintXml(xml)).toEqual(prettyPrintXml(EXPECTED_XML))
+	})
+})
 
-const EXPECTED_XML =
-`<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="gpxjs">
+const EXPECTED_XML = `<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="gpxjs">
   <metadata>
     <name>GPX Test</name>
     <desc>Test Description</desc>
@@ -102,22 +101,22 @@ const EXPECTED_XML =
  ****/
 
 const XSLT_PRETTY_PRINT = [
-  '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform">',
-  '  <xsl:template match="node()|@*">',
-  '    <xsl:copy><xsl:apply-templates select="node()|@*"/></xsl:copy>',
-  '  </xsl:template>',
-  '  <xsl:output indent="yes"/>',
-  '</xsl:stylesheet>',
-].join('\n');
+	'<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform">',
+	'  <xsl:template match="node()|@*">',
+	'    <xsl:copy><xsl:apply-templates select="node()|@*"/></xsl:copy>',
+	'  </xsl:template>',
+	'  <xsl:output indent="yes"/>',
+	'</xsl:stylesheet>',
+].join('\n')
 
 function prettyPrintXml(xml) {
-  const parser = new DOMParser();
+	const parser = new DOMParser()
 
-  const xsltDoc = parser.parseFromString(XSLT_PRETTY_PRINT, 'text/xml');
-  const xsltProcessor = new XSLTProcessor();
-  xsltProcessor.importStylesheet(xsltDoc);
+	const xsltDoc = parser.parseFromString(XSLT_PRETTY_PRINT, 'text/xml')
+	const xsltProcessor = new XSLTProcessor()
+	xsltProcessor.importStylesheet(xsltDoc)
 
-  const doc = parser.parseFromString(xml, 'text/xml');
-  const prettyDoc = xsltProcessor.transformToDocument(doc);
-  return new XMLSerializer().serializeToString(prettyDoc);
+	const doc = parser.parseFromString(xml, 'text/xml')
+	const prettyDoc = xsltProcessor.transformToDocument(doc)
+	return new XMLSerializer().serializeToString(prettyDoc)
 }

--- a/test/test-gpx-file.js
+++ b/test/test-gpx-file.js
@@ -1,5 +1,4 @@
-export const testGPXFile = 
-`<?xml version="1.0" encoding="UTF-8" ?>
+export const testGPXFile = `<?xml version="1.0" encoding="UTF-8" ?>
 <gpx version="1.1" creator="Test Creator">
     <metadata>
         <name>GPX Test</name>
@@ -84,116 +83,116 @@ export const testGPXFile =
 </gpx>`
 
 export const expectedMetadata = {
-    name: "GPX Test",
-    description: "Test Description",
-    time: "2020-01-12T21:32:52",
-    link: {
-        href: "https://test2.com",
-        text: "General Website",
-        type: "Web"
-    },
-    author: {
-        name: "Test Author",
-        email: {
-            id: "test",
-            domain: "test.com",
-        },
-        link: {
-            href: "https://test.com",
-            text: "Author Website",
-            type: "Web"
-        }
-    },
+	name: 'GPX Test',
+	description: 'Test Description',
+	time: '2020-01-12T21:32:52',
+	link: {
+		href: 'https://test2.com',
+		text: 'General Website',
+		type: 'Web',
+	},
+	author: {
+		name: 'Test Author',
+		email: {
+			id: 'test',
+			domain: 'test.com',
+		},
+		link: {
+			href: 'https://test.com',
+			text: 'Author Website',
+			type: 'Web',
+		},
+	},
 }
 
 export const expectedWaypoint = {
-    name: "Porte de Carquefou",
-    latitude: 47.253146555709,
-    longitude: -1.5153741828293,
-    elevation: 35,
-    comment: "Warning",
-    description: "Route",
-    time: new Date("2020-02-02T07:54:30.000Z")
+	name: 'Porte de Carquefou',
+	latitude: 47.253146555709,
+	longitude: -1.5153741828293,
+	elevation: 35,
+	comment: 'Warning',
+	description: 'Route',
+	time: new Date('2020-02-02T07:54:30.000Z'),
 }
 
 export const expectedTrack = {
-    name: "Track",
-    comment: "Bridge",
-    description: "Test track",
-    src: "GPX Test Device",
-    number: "1",
-    type: "MTB",
-    link: {
-        href: "https://test.com",
-        text: "Track Website",
-        type: "Web"
-    },
-    distance: {
-        cumulative: [0],
-        total: 0,
-    },
-    duration: {
-        cumulative: [0],
-        movingDuration: 0,
-        totalDuration: 0,
-    },
-    elevation: {
-        average: 12.36,
-        maximum: 12.36,
-        minimum: 12.36,
-    },
-    points: [
-        {
-            elevation: 12.36,
-            extensions: {
-                floatext: 1.75,
-                intext: 3,
-                strext: "testString",
-                subext: {
-                    subval: 33
-                },
-            },
-            latitude: 47.2278526991611,
-            longitude: -1.5521714646550901,
-            time: new Date("2020-02-02T07:54:30.000Z"),
-        }
-    ],
-    slopes: [],
+	name: 'Track',
+	comment: 'Bridge',
+	description: 'Test track',
+	src: 'GPX Test Device',
+	number: '1',
+	type: 'MTB',
+	link: {
+		href: 'https://test.com',
+		text: 'Track Website',
+		type: 'Web',
+	},
+	distance: {
+		cumulative: [0],
+		total: 0,
+	},
+	duration: {
+		cumulative: [0],
+		movingDuration: 0,
+		totalDuration: 0,
+	},
+	elevation: {
+		average: 12.36,
+		maximum: 12.36,
+		minimum: 12.36,
+	},
+	points: [
+		{
+			elevation: 12.36,
+			extensions: {
+				floatext: 1.75,
+				intext: 3,
+				strext: 'testString',
+				subext: {
+					subval: 33,
+				},
+			},
+			latitude: 47.2278526991611,
+			longitude: -1.5521714646550901,
+			time: new Date('2020-02-02T07:54:30.000Z'),
+		},
+	],
+	slopes: [],
 }
 
 export const expectedRoute = {
-    name: "Track",
-    comment: "Bridge",
-    description: "Test route",
-    src: "GPX Test Device",
-    number: "1",
-    type: "MTB",
-    link: {
-        href: "https://test.com",
-        text: "Route Website",
-        type: "Web"
-    },
-    distance: {
-        cumulative: [0],
-        total: 0,
-    },
-    duration: {
-        cumulative: [0],
-        movingDuration: 0,
-        totalDuration: 0,
-    },
-    elevation: {
-        average: 12.36,
-        maximum: 12.36,
-        minimum: 12.36,
-    },
-    points: [
-        {
-            latitude: 47.2278526991611,
-            longitude: -1.5521714646550901,
-            elevation: 12.36,
-            time: new Date("2020-02-02T07:54:30.000Z"),
-        },
-    ],
-    slopes: [],
+	name: 'Track',
+	comment: 'Bridge',
+	description: 'Test route',
+	src: 'GPX Test Device',
+	number: '1',
+	type: 'MTB',
+	link: {
+		href: 'https://test.com',
+		text: 'Route Website',
+		type: 'Web',
+	},
+	distance: {
+		cumulative: [0],
+		total: 0,
+	},
+	duration: {
+		cumulative: [0],
+		movingDuration: 0,
+		totalDuration: 0,
+	},
+	elevation: {
+		average: 12.36,
+		maximum: 12.36,
+		minimum: 12.36,
+	},
+	points: [
+		{
+			latitude: 47.2278526991611,
+			longitude: -1.5521714646550901,
+			elevation: 12.36,
+			time: new Date('2020-02-02T07:54:30.000Z'),
+		},
+	],
+	slopes: [],
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,40 +1,40 @@
-import { resolve } from 'path'
+import { resolve } from 'node:path'
+import { playwright } from '@vitest/browser-playwright'
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
-import { playwright } from '@vitest/browser-playwright'
 
 export default defineConfig({
-    build: {
-        // Intentional: keep function/class names intact (e.g. `ParsedGPX`)
-        // instead of letting them get mangled to single letters. This has
-        // been the behavior since the library's first commit, so we're
-        // preserving it deliberately rather than dropping it on a bundler
-        // upgrade. It keeps stack traces and any `.name`/`.constructor.name`
-        // usage (ours or a consumer's) readable, at the cost of a few extra
-        // bytes. Whitespace and dead code are still stripped normally.
-        minify: { mangle: false },
-        lib: {
-            entry: resolve(__dirname, 'lib/index.ts'),
-            name: 'gpxjs',
-            fileName: 'gpxjs',
-        }
-    },
-    test: {
-        browser: {
-            provider: playwright(),
-            enabled: true,
-            headless: true,
-            instances: [{ browser: 'chromium' }],
-        },
-    },
-    plugins: [
-        dts({
-            entryRoot: 'lib',
-            include: ['lib'],
-        }),
-    ],
-    define: {
-        // Shim required for using the custom parser
-        global: {},
-    },
+	build: {
+		// Intentional: keep function/class names intact (e.g. `ParsedGPX`)
+		// instead of letting them get mangled to single letters. This has
+		// been the behavior since the library's first commit, so we're
+		// preserving it deliberately rather than dropping it on a bundler
+		// upgrade. It keeps stack traces and any `.name`/`.constructor.name`
+		// usage (ours or a consumer's) readable, at the cost of a few extra
+		// bytes. Whitespace and dead code are still stripped normally.
+		minify: { mangle: false },
+		lib: {
+			entry: resolve(__dirname, 'lib/index.ts'),
+			name: 'gpxjs',
+			fileName: 'gpxjs',
+		},
+	},
+	test: {
+		browser: {
+			provider: playwright(),
+			enabled: true,
+			headless: true,
+			instances: [{ browser: 'chromium' }],
+		},
+	},
+	plugins: [
+		dts({
+			entryRoot: 'lib',
+			include: ['lib'],
+		}),
+	],
+	define: {
+		// Shim required for using the custom parser
+		global: {},
+	},
 })


### PR DESCRIPTION
## Summary
- Adds Biome as a single lint and format tool, replacing the unused Prettier config block (ESLint was never actually installed).
- Migrated existing Prettier settings (tabs, no semicolons, es5 trailing commas) into biome.json so formatting stays consistent with the project's style.
- Reformatted the whole codebase with Biome and applied its safe autofixes (quote style, == to ===, isNaN to Number.isNaN, unused imports/vars, node: import protocol).
- Added lint, lint:fix, and format npm scripts, and wired biome check into CI.
- Fixed a latent bug found along the way: two stale @ts-ignore comments in lib/parsed_gpx.ts were on the wrong line and no longer suppressed any real error. Removed them.

Closes #19

## Test plan
- [x] npm run build succeeds
- [x] npx vitest run passes (5/5)
- [x] npx biome check . reports zero errors (9 remaining warnings are noExplicitAny/noBannedTypes, intentionally deferred to #23's type unification work)
