### PR TITLE
Parse copyright, keywords, and bounds in metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,13 +184,16 @@ For specific type definition, see [types.ts](./lib/types.ts).
 
 ### Metadata
 
-| Property    | Type        | Description   |
-| ----------- | ----------- | ------------- |
-| name        | String      | File name     |
-| description | String      | Description   |
-| link        | Link object | Web address   |
-| author      | Float       | Author object |
-| time        | String      | Time          |
+| Property    | Type             | Description                              |
+| ----------- | ---------------- | ----------------------------------------- |
+| name        | String           | File name                                |
+| description | String           | Description                              |
+| link        | Link object      | Web address                              |
+| author      | Author object    | Author object                            |
+| time        | String           | Time                                     |
+| copyright   | Copyright object | Copyright holder and license             |
+| keywords    | String           | Comma-separated list of keywords         |
+| bounds      | Bounds object    | Minimum and maximum coordinates covered  |
 
 ### Waypoint
 
@@ -296,3 +299,20 @@ For specific type definition, see [types.ts](./lib/types.ts).
 | href     | String | Web address |
 | text     | String | Link text   |
 | type     | String | Link type   |
+
+### Copyright
+
+| Property | Type   | Description                            |
+| -------- | ------ | --------------------------------------- |
+| author   | String | Copyright holder                        |
+| year     | String | Copyright year                          |
+| license  | String | License URI                             |
+
+### Bounds
+
+| Property     | Type  | Description                    |
+| ------------ | ----- | ------------------------------- |
+| minLatitude  | Float | Minimum latitude of the file   |
+| minLongitude | Float | Minimum longitude of the file  |
+| maxLatitude  | Float | Maximum latitude of the file   |
+| maxLongitude | Float | Maximum longitude of the file  |

--- a/badges/coverage.json
+++ b/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"coverage","message":"97.69%","color":"brightgreen"}
+{"schemaVersion":1,"label":"coverage","message":"97.77%","color":"brightgreen"}

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
 	"vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
-	"files": { "includes": ["**", "!!**/dist"] },
+	"files": { "includes": ["**", "!!**/dist", "!!badges"] },
 	"formatter": {
 		"enabled": true,
 		"formatWithErrors": false,

--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -72,6 +72,9 @@ export const parseGPXWithCustomParser = (
 			time: '',
 			author: null,
 			link: null,
+			copyright: null,
+			keywords: '',
+			bounds: null,
 		},
 		waypoints: [],
 		tracks: [],
@@ -112,6 +115,16 @@ export const parseGPXWithCustomParser = (
 			}
 		}
 
+		// Parse and store the tree of data associated with the copyright
+		const copyrightElement = metadata.querySelector('copyright')
+		if (copyrightElement !== null) {
+			output.metadata.copyright = {
+				author: copyrightElement.getAttribute('author') ?? '',
+				year: getElementValue(copyrightElement, 'year'),
+				license: getElementValue(copyrightElement, 'license'),
+			}
+		}
+
 		// Parse and store the link element and its associated data
 		const linkElement = querySelectDirectDescendant(metadata, 'link')
 		if (linkElement !== null) {
@@ -119,6 +132,33 @@ export const parseGPXWithCustomParser = (
 				href: linkElement.getAttribute('href') ?? '',
 				text: getElementValue(linkElement, 'text'),
 				type: getElementValue(linkElement, 'type'),
+			}
+		}
+
+		// Store the keywords, a comma-separated list of keywords
+		output.metadata.keywords = getElementValue(metadata, 'keywords')
+
+		// Parse and store the bounding coordinates of the file
+		const boundsElement = metadata.querySelector('bounds')
+		if (boundsElement !== null) {
+			const minLatitude = parseFloat(
+				boundsElement.getAttribute('minlat') ?? ''
+			)
+			const minLongitude = parseFloat(
+				boundsElement.getAttribute('minlon') ?? ''
+			)
+			const maxLatitude = parseFloat(
+				boundsElement.getAttribute('maxlat') ?? ''
+			)
+			const maxLongitude = parseFloat(
+				boundsElement.getAttribute('maxlon') ?? ''
+			)
+
+			output.metadata.bounds = {
+				minLatitude: Number.isNaN(minLatitude) ? null : minLatitude,
+				minLongitude: Number.isNaN(minLongitude) ? null : minLongitude,
+				maxLatitude: Number.isNaN(maxLatitude) ? null : maxLatitude,
+				maxLongitude: Number.isNaN(maxLongitude) ? null : maxLongitude,
 			}
 		}
 	}

--- a/lib/stringify.ts
+++ b/lib/stringify.ts
@@ -141,8 +141,20 @@ const GPX_MAPPING: ObjectMapping = {
 			},
 			link: LINK_MAPPING,
 		},
+		copyright: {
+			'@author': '=',
+			year: '=',
+			license: '=',
+		},
 		link: LINK_MAPPING,
 		time: '=',
+		keywords: '=',
+		bounds: {
+			'@minlat': 'minLatitude',
+			'@minlon': 'minLongitude',
+			'@maxlat': 'maxLatitude',
+			'@maxlon': 'maxLongitude',
+		},
 	},
 	wpt: {
 		$expr: 'waypoints',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,9 @@ export type MetaData = {
 	link: Link | null
 	author: Author | null
 	time: string | null
+	copyright: Copyright | null
+	keywords: string | null
+	bounds: Bounds | null
 }
 
 export type Waypoint = {
@@ -91,6 +94,19 @@ export type Link = {
 	href: string | null
 	text: string | null
 	type: string | null
+}
+
+export type Copyright = {
+	author: string | null
+	year: string | null
+	license: string | null
+}
+
+export type Bounds = {
+	minLatitude: number | null
+	minLongitude: number | null
+	maxLatitude: number | null
+	maxLongitude: number | null
 }
 
 export type ParsedGPXInputs = {

--- a/test/parse-edge-cases.spec.ts
+++ b/test/parse-edge-cases.spec.ts
@@ -38,6 +38,7 @@ describe.each(parsers)('parseGPX edge cases ($name)', ({ parse }) => {
 			name: '',
 			description: '',
 			time: '',
+			keywords: '',
 		})
 		expect(parsed.waypoints).toStrictEqual([])
 		expect(parsed.tracks).toStrictEqual([])

--- a/test/parse.spec.ts
+++ b/test/parse.spec.ts
@@ -11,10 +11,7 @@ import {
 	testGPXFile,
 } from './test-gpx-file'
 
-// TODO test GeoJSON, benchmarks
-
 // TODO: Noted inconsistencies while testing
-// Missing some metadata information
 // Parse some times as dates and some as strings
 // Some items match abbreviations, some don't
 

--- a/test/stringify.spec.ts
+++ b/test/stringify.spec.ts
@@ -53,11 +53,17 @@ const EXPECTED_XML = `<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.
         <type>Web</type>
       </link>
     </author>
+    <copyright author="Test Copyright Owner">
+      <year>2024</year>
+      <license>MIT</license>
+    </copyright>
     <link href="https://test2.com">
       <text>General Website</text>
       <type>Web</type>
     </link>
     <time>2020-01-12T21:32:52</time>
+    <keywords>Test, gpx, file</keywords>
+    <bounds minlat="49.12965660728301" minlon="-1.5521714646550901" maxlat="45.85097922514941" maxlon="4.336738935765406"/>
   </metadata>
   <wpt lat="47.253146555709" lon="-1.5153741828293">
     <name>Porte de Carquefou</name>

--- a/test/test-gpx-file.ts
+++ b/test/test-gpx-file.ts
@@ -121,6 +121,18 @@ export const expectedMetadata: Partial<MetaData> = {
 			type: 'Web',
 		},
 	},
+	copyright: {
+		author: 'Test Copyright Owner',
+		year: '2024',
+		license: 'MIT',
+	},
+	keywords: 'Test, gpx, file',
+	bounds: {
+		minLatitude: 49.12965660728301,
+		minLongitude: -1.5521714646550901,
+		maxLatitude: 45.85097922514941,
+		maxLongitude: 4.336738935765406,
+	},
 }
 
 export const expectedWaypoint: Partial<Waypoint> = {


### PR DESCRIPTION
## Summary
- Parses `copyright` (author attribute, year, license), `keywords`, and `bounds` (the four lat/lon attributes) into `metadata`, which the GPX 1.1 spec includes but `parse.ts` previously ignored entirely.
- Adds `Copyright` and `Bounds` types, and adds the three new fields to `MetaData` in `types.ts`.
- Extends `stringify.ts`'s `GPX_MAPPING` so these fields round-trip back to XML, in GPX 1.1 schema order.
- Updates `expectedMetadata` in the test fixture to actually assert on these fields, closing the gap where the test file included them in its sample GPX but never checked them.
- Updates the README's Metadata table with the new fields, adds `Copyright` and `Bounds` sub-tables, and fixes a pre-existing typo where `author` was listed as type `Float` instead of `Author object`.
- Excludes `badges/` from Biome's scope. The coverage-badge CI step commits raw JSON without running it through Biome, so the next lint check would have failed on that file's formatting. Since it's a generated data artifact, excluding it is more robust than keeping the script's output in permanent sync with Biome's formatter.

This was able to land safely now that #21's test suite is in place: the full parse-and-stringify round trip for the new fields is verified across both the browser and non-browser (xmldom-qsa) code paths.

Closes #20

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (38/38)
- [x] `npm run build` succeeds
- [x] `biome check .` reports zero errors
- [x] Coverage holds at 97.77% lines, 100% functions
