### PR TITLE
Improve parsing performance, especially the xmldom-qsa path

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ _Last updated 2026-07-03 by `npm run bench:update-readme`, normally run in CI on
 
 | Environment | Operation | Mean time | Ops/sec |
 | --- | --- | --- | --- |
-| Node (xmldom-qsa) | parseGPXWithCustomParser: parses a 10000-point track | 141.21 ms | 7.08 (±6.58%) |
-| Node (xmldom-qsa) | toGeoJSON: converts a 10000-point track | 0.608 ms | 1,644 (±1.92%) |
-| Browser (DOMParser) | parseGPX: parses a 10000-point track | 99.41 ms | 10.06 (±1.54%) |
-| Browser (DOMParser) | toGeoJSON: converts a 10000-point track | 0.535 ms | 1,869 (±1.17%) |
+| Node (xmldom-qsa) | parseGPXWithCustomParser: parses a 10000-point track | 107.63 ms | 9.29 (±5.03%) |
+| Node (xmldom-qsa) | toGeoJSON: converts a 10000-point track | 0.661 ms | 1,512 (±2.63%) |
+| Browser (DOMParser) | parseGPX: parses a 10000-point track | 78.46 ms | 12.75 (±1.66%) |
+| Browser (DOMParser) | toGeoJSON: converts a 10000-point track | 0.505 ms | 1,980 (±1.16%) |
 <!-- BENCHMARKS:END -->
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ _Last updated 2026-07-03 by `npm run bench:update-readme`, normally run in CI on
 
 | Environment | Operation | Mean time | Ops/sec |
 | --- | --- | --- | --- |
-| Node (xmldom-qsa) | parseGPXWithCustomParser: parses a 10000-point track | 9572.00 ms | 0.10 (±0.24%) |
-| Node (xmldom-qsa) | toGeoJSON: converts a 10000-point track | 0.783 ms | 1,277 (±1.43%) |
-| Browser (DOMParser) | parseGPX: parses a 10000-point track | 336.79 ms | 2.97 (±5.18%) |
-| Browser (DOMParser) | toGeoJSON: converts a 10000-point track | 0.774 ms | 1,291 (±1.56%) |
+| Node (xmldom-qsa) | parseGPXWithCustomParser: parses a 10000-point track | 141.21 ms | 7.08 (±6.58%) |
+| Node (xmldom-qsa) | toGeoJSON: converts a 10000-point track | 0.608 ms | 1,644 (±1.92%) |
+| Browser (DOMParser) | parseGPX: parses a 10000-point track | 99.41 ms | 10.06 (±1.54%) |
+| Browser (DOMParser) | toGeoJSON: converts a 10000-point track | 0.535 ms | 1,869 (±1.17%) |
 <!-- BENCHMARKS:END -->
 
 ## Options

--- a/lib/gpx_mapping.ts
+++ b/lib/gpx_mapping.ts
@@ -46,26 +46,29 @@ export function writeExtensions(
 export function readExtensions(srcElem: Element): Extensions {
 	const extensions: Extensions = {}
 
-	Array.from(srcElem.childNodes)
-		.filter((child: ChildNode) => child.nodeType === 1)
-		.forEach((child: ChildNode) => {
-			const tagName = child.nodeName
-			if (
-				child.childNodes?.length === 1 &&
-				child.childNodes[0].nodeType === 3 &&
-				child.childNodes[0].textContent
-			) {
-				const textContent = child.childNodes[0].textContent.trim()
-				const value = Number.isNaN(+textContent)
-					? textContent
-					: parseFloat(textContent)
-				extensions[tagName] = value
-			} else {
-				extensions[tagName] = readExtensions(
-					child as unknown as Element
-				)
-			}
-		})
+	// Walk childNodes directly rather than Array.from(...).filter().forEach():
+	// this runs once per point on a track, and the intermediate array plus
+	// per-child closures were needless allocation (issue #32).
+	const children = srcElem.childNodes
+	for (let i = 0; i < children.length; i++) {
+		const child = children[i]
+		if (child.nodeType !== 1) continue
+
+		const tagName = child.nodeName
+		if (
+			child.childNodes?.length === 1 &&
+			child.childNodes[0].nodeType === 3 &&
+			child.childNodes[0].textContent
+		) {
+			const textContent = child.childNodes[0].textContent.trim()
+			const value = Number.isNaN(+textContent)
+				? textContent
+				: parseFloat(textContent)
+			extensions[tagName] = value
+		} else {
+			extensions[tagName] = readExtensions(child as unknown as Element)
+		}
+	}
 
 	return extensions
 }

--- a/lib/remove_empty_fields.ts
+++ b/lib/remove_empty_fields.ts
@@ -19,9 +19,16 @@ export function removeEmptyFields<T>(value: T): T {
 		return value.map(removeEmptyFields) as T
 	}
 
-	const entries = Object.entries(value)
-		.filter(([, fieldValue]) => fieldValue != null)
-		.map(([key, fieldValue]) => [key, removeEmptyFields(fieldValue)])
+	// Build the cleaned object in a single pass. Object.entries().filter().map()
+	// + Object.fromEntries() is a more declarative way to write this, but it
+	// allocates an entries array, a `[key, value]` pair per field, and two more
+	// arrays before rebuilding the object; on a large track this runs once per
+	// point and showed up as a real share of parse time (issue #32).
+	const result: Record<string, unknown> = {}
+	for (const key of Object.keys(value)) {
+		const fieldValue = (value as Record<string, unknown>)[key]
+		if (fieldValue != null) result[key] = removeEmptyFields(fieldValue)
+	}
 
-	return Object.fromEntries(entries) as T
+	return result as T
 }

--- a/lib/xml_object_mapping.ts
+++ b/lib/xml_object_mapping.ts
@@ -229,8 +229,15 @@ export function readObject(
 ) {
 	initializeDefaults(mapping, dstObj)
 
+	// Group the element's direct children by tag name once, up front, rather
+	// than re-scanning them for every field in the mapping. A single element
+	// (e.g. a track point) can have ~20 fields, so doing an independent
+	// child lookup per field turns parsing into O(fields * children) with a
+	// large constant, which dominated the xmldom-qsa parse time (issue #32).
+	const childrenByTag = groupChildElements(srcElem)
+
 	for (const xmlName in mapping) {
-		readField(xmlName, mapping[xmlName], srcElem, dstObj)
+		readField(xmlName, mapping[xmlName], srcElem, childrenByTag, dstObj)
 	}
 }
 
@@ -238,6 +245,7 @@ function readField(
 	xmlName: string,
 	mapping: FieldMapping,
 	srcElem: Element,
+	childrenByTag: Map<string, Element[]>,
 	dstObj: any
 ) {
 	const { isAttribute, name, targetField } = resolveField(xmlName, mapping)
@@ -246,13 +254,13 @@ function readField(
 		case 'scalar': {
 			const raw = isAttribute
 				? srcElem.getAttribute(name)
-				: getElementValue(srcElem, name)
+				: getElementValue(childrenByTag, name)
 			dstObj[targetField] = coerceValue(raw, mapping.type)
 			return
 		}
 		case 'object': {
-			const childElems = directChildElements(srcElem, name)
-			if (childElems.length === 0) return
+			const childElems = childrenByTag.get(name)
+			if (childElems === undefined) return
 
 			const target = mapping.self ? dstObj : {}
 			readObject(mapping.fields, childElems[0], target)
@@ -269,6 +277,7 @@ function readField(
 			// in from a later instance if the first instance left it at its
 			// default, since there's no clear way to merge two scalars.
 			for (const extraElem of childElems.slice(1)) {
+				const extraChildrenByTag = groupChildElements(extraElem)
 				for (const extraXmlName in mapping.fields) {
 					const extraFieldMapping = mapping.fields[extraXmlName]
 					const { targetField: extraTargetField } = resolveField(
@@ -283,6 +292,7 @@ function readField(
 							extraXmlName,
 							extraFieldMapping,
 							extraElem,
+							extraChildrenByTag,
 							target
 						)
 					}
@@ -291,7 +301,9 @@ function readField(
 			return
 		}
 		case 'array': {
-			for (const childElem of directChildElements(srcElem, name)) {
+			const childElems = childrenByTag.get(name)
+			if (childElems === undefined) return
+			for (const childElem of childElems) {
 				const item = {}
 				readObject(mapping.items, childElem, item)
 				;(dstObj[targetField] as any[]).push(item)
@@ -299,7 +311,7 @@ function readField(
 			return
 		}
 		case 'custom': {
-			const childElem = directChildElements(srcElem, name)[0]
+			const childElem = childrenByTag.get(name)?.[0]
 			if (childElem === undefined) return
 			dstObj[targetField] = mapping.read(childElem)
 			return
@@ -385,14 +397,18 @@ function coerceValue(raw: string | null, type?: FieldType) {
 }
 
 /**
- * Extracts a value from a direct child of the given element, by tag name.
+ * Extracts the text value of the first direct child with the given tag name,
+ * or null if there is no such child.
  *
- * @param parent An element to extract a value from
+ * @param childrenByTag The parent's direct children, grouped by tag name
  * @param tag The tag of the child element that contains the desired data (e.g. "time" or "name")
  * @returns A string containing the desired value
  */
-function getElementValue(parent: Element, tag: string): string | null {
-	const element = directChildElements(parent, tag)[0]
+function getElementValue(
+	childrenByTag: Map<string, Element[]>,
+	tag: string
+): string | null {
+	const element = childrenByTag.get(tag)?.[0]
 
 	if (element !== undefined) {
 		return element.firstChild?.textContent ?? element.innerHTML ?? null
@@ -401,25 +417,41 @@ function getElementValue(parent: Element, tag: string): string | null {
 }
 
 /**
- * Finds the direct children of the given element that match the given tag
- * name. Restricting the search to direct children (rather than any
- * descendant) avoids accidentally matching a same-named tag nested further
- * down, e.g. a track's own `<type>` versus its `<link><type>`.
+ * Groups an element's direct child elements by tag name, in document order.
  *
- * @param parent A parent element to search within
- * @param tag The tag of the child elements to search for
- * @returns The matching direct child elements, in document order
+ * Restricting to direct children (rather than any descendant) avoids
+ * accidentally matching a same-named tag nested further down, e.g. a track's
+ * own `<type>` versus its `<link><type>`. Grouping all children in a single
+ * pass lets `readObject` look each field up by tag name instead of
+ * re-scanning the children (or, worse, re-running a `querySelectorAll`) once
+ * per field. See the note in `readObject` for why this matters (issue #32).
+ *
+ * @param parent A parent element to collect the children of
+ * @returns A map from tag name to the matching direct child elements
  */
-function directChildElements(parent: Element, tag: string): Element[] {
-	try {
-		// Find all matching direct descendants
-		return Array.from(parent.querySelectorAll(`:scope > ${tag}`))
-	} catch (_e) {
-		// Handle non-browser or older environments that don't support :scope
-		return (Array.from(parent.childNodes) as unknown as Element[]).filter(
-			(element) => element && element.tagName === tag
-		)
+function groupChildElements(parent: Element): Map<string, Element[]> {
+	const childrenByTag = new Map<string, Element[]>()
+
+	const children = parent.childNodes
+	for (let i = 0; i < children.length; i++) {
+		const node = children[i]
+		// Element nodes only; skip text, comments, etc. Matching by tagName
+		// (rather than a CSS type selector) is namespace-insensitive in the
+		// same way the previous querySelectorAll-free fallback path was, which
+		// is what GPX's default-namespaced elements need.
+		if (node.nodeType !== 1) continue
+		const element = node as unknown as Element
+		const tag = element.tagName
+
+		const existing = childrenByTag.get(tag)
+		if (existing !== undefined) {
+			existing.push(element)
+		} else {
+			childrenByTag.set(tag, [element])
+		}
 	}
+
+	return childrenByTag
 }
 
 /* v8 ignore start -- only reachable if a new FieldMapping kind is added


### PR DESCRIPTION
Closes #32.

Investigates and improves parsing performance, with the biggest win on the xmldom-qsa (non-browser) path flagged in the issue. Every change is backed by benchmark numbers from `npm run bench`, not just a cleanup.

## Results (10,000-point track)

| Path | Before (main) | After |
| --- | --- | --- |
| Node (xmldom-qsa) | ~9,572 ms | ~108 ms |
| Browser (DOMParser) | ~337 ms | ~78 ms |

The roughly 40x gap between the two paths that the issue called out is effectively gone. README benchmark table is regenerated.

## What changed

**1. Group each element's children once instead of searching per field (`xml_object_mapping.ts`).**
`readObject` was calling `directChildElements(srcElem, name)` once for every field in the mapping, and each call ran `querySelectorAll(':scope > tag')`, which parses a selector and scans the children every time. With ~20 wptType fields per point across 10,000 points, that was hundreds of thousands of selector-parse-and-scan operations, and it got worse when full schema coverage (#33) added more fields. Now the element's direct children are grouped into a `Map<tagName, Element[]>` in a single pass, and each field does a map lookup. This also let the `querySelectorAll` path go away entirely (the single `childNodes` walk works the same in browser and Node), so the old try/catch fallback is gone. Behavior is unchanged: same direct-children-only matching, same field-to-element mapping.

**2. Single-pass `removeEmptyFields` (`remove_empty_fields.ts`).**
This runs on every parse by default and rebuilt every object (all 10,000 points) via `Object.entries().filter().map()` + `Object.fromEntries()`, allocating four throwaway structures per object. Rewritten as one `for...of Object.keys()` loop that builds the result directly. Isolated, this stage dropped from ~32 ms to ~5 ms. Same semantics: own enumerable keys, null/undefined dropped, Date and array handling unchanged.

**3. Allocation-free `readExtensions` walk (`gpx_mapping.ts`).**
Replaced `Array.from(childNodes).filter().forEach()` with an indexed `for` loop over `childNodes`, dropping the intermediate array and per-child closures on a function that runs once per point.

## Not included (filed as follow-ups)

- `calculateDuration`'s inner lookback loop is O(n^2) in the worst case (a track densely sampled within its 10-second window). It is effectively linear for normal 1 Hz data and is not a current bottleneck, so it is tracked separately as a robustness fix.
- Over half the remaining Node time is inside xmldom-qsa's own `parseFromString`, which we do not control. Moving past that floor means swapping to a streaming/SAX parser that builds our object directly, a larger and higher-risk change tracked separately.

## Verification

- 86/86 tests pass across both the browser (Chromium) and node (xmldom-qsa) vitest projects
- 100% coverage on all metrics (statements, branches, functions, lines)
- Clean `tsc` and `biome`
